### PR TITLE
Fixed Recipe for Factory ventilator

### DIFF
--- a/mods/sbz_decor/init.lua
+++ b/mods/sbz_decor/init.lua
@@ -86,7 +86,7 @@ minetest.register_node("sbz_decor:factory_ventilator", {
 minetest.register_craft({
     output = "sbz_decor:factory_ventilator",
     type = "shapeless",
-    recipe = { "sbz_decor:factory_floor", "sbz_decor:factory_floor", "sbz_chem:lithium_powder", "sbz_chem:lead_powder" }
+    recipe = { "sbz_decor:factory_floor", "sbz_decor:factory_floor", "sbz_chem:lithium_powder", "sbz_chem:aluminum_powder" }
 })
 
 minetest.register_node("sbz_decor:factory_warning", unifieddyes.def {


### PR DESCRIPTION
The Factor Ventilator Node requires `lead_powder`  to craft which is disabled. (Stopping you from completing the quest book) 
![broken_recipe](https://github.com/user-attachments/assets/b962be1f-605b-4e53-bd9d-c826438a3296)

It now uses `aluminum_powder` instead for crafting.
![fixed_recipe](https://github.com/user-attachments/assets/c859b626-9adf-455c-a309-a3d01a7347da)
