### PR TITLE
Add threshold mode

### DIFF
--- a/mods/sbz_pipeworks/filter_injector.lua
+++ b/mods/sbz_pipeworks/filter_injector.lua
@@ -261,11 +261,14 @@ minetest.register_node("pipeworks:automatic_filter_injector", {
                                 count = math.min(filterfor.count, count)
                             end
                         end
+                        core.chat_send_all("_______")
+                        core.chat_send_all(count)
+                        core.chat_send_all(filterfor.count)
                         if exmatch_mode == 2 then
-                            if count == 0 then
-                                return false
-                            else
+                            if filterfor.count < count then
                                 count = count - filterfor.count
+                            else
+                                return false
                             end
                         end
                     end

--- a/mods/sbz_pipeworks/filter_injector.lua
+++ b/mods/sbz_pipeworks/filter_injector.lua
@@ -20,7 +20,8 @@ local function set_filter_formspec(meta)
                 "Sequence slots by Rotation" }) ..
         fs_helpers.cycling_button(meta, "button[" .. (10.2 - (0.22) - 4) .. ",4.5;4,1", "exmatch_mode",
             { "Exact match - off",
-                "Exact match - on" }) ..
+                "Exact match - on",
+               "Threshold" }) ..
         pipeworks.fs_helpers.get_inv(6) ..
         "listring[]"
 
@@ -256,8 +257,13 @@ minetest.register_node("pipeworks:automatic_filter_injector", {
                         if exmatch_mode ~= 0 and filterfor.count > count then
                             return false -- not enough, fail
                         else
-                            -- limit quantity to filter amount
-                            count = math.min(filterfor.count, count)
+                            if exmatch_mode ~= 2 then
+                                -- limit quantity to filter amount
+                                count = math.min(filterfor.count, count)
+                            else
+                                -- set item to the threshhold
+                            count = count - filterfor.count
+                            end
                         end
                     end
                     if fromtube.remove_items then

--- a/mods/sbz_pipeworks/filter_injector.lua
+++ b/mods/sbz_pipeworks/filter_injector.lua
@@ -21,7 +21,7 @@ local function set_filter_formspec(meta)
         fs_helpers.cycling_button(meta, "button[" .. (10.2 - (0.22) - 4) .. ",4.5;4,1", "exmatch_mode",
             { "Exact match - off",
                 "Exact match - on",
-               "Threshold" }) ..
+                "Threshold"}) ..
         pipeworks.fs_helpers.get_inv(6) ..
         "listring[]"
 
@@ -253,18 +253,18 @@ minetest.register_node("pipeworks:automatic_filter_injector", {
                     end
                     local item
                     local count = math.min(stack:get_count(), doRemove)
-                    if filterfor.count and (filterfor.count > 1) then
-                        if exmatch_mode ~= 0 and filterfor.count > count then
+                    if exmatch_mode == 1 then
+                        if  filterfor.count > count then
                             return false -- not enough, fail
                         else
-                            if exmatch_mode ~= 2 then
-                                -- limit quantity to filter amount
-                                count = math.min(filterfor.count, count)
-                            else
-                                -- set item to the threshhold
-                            count = count - filterfor.count
-                            end
+                            -- limit quantity to filter amount
+                            count = math.min(filterfor.count, count)
                         end
+                    end
+                    if exmatch_mode == 2
+                    then
+                        count = count - filterfor.count
+
                     end
                     if fromtube.remove_items then
                         -- it could be the entire stack...

--- a/mods/sbz_pipeworks/filter_injector.lua
+++ b/mods/sbz_pipeworks/filter_injector.lua
@@ -261,9 +261,6 @@ minetest.register_node("pipeworks:automatic_filter_injector", {
                                 count = math.min(filterfor.count, count)
                             end
                         end
-                        core.chat_send_all("_______")
-                        core.chat_send_all(count)
-                        core.chat_send_all(filterfor.count)
                         if exmatch_mode == 2 then
                             if filterfor.count < count then
                                 count = count - filterfor.count

--- a/mods/sbz_pipeworks/filter_injector.lua
+++ b/mods/sbz_pipeworks/filter_injector.lua
@@ -21,7 +21,7 @@ local function set_filter_formspec(meta)
         fs_helpers.cycling_button(meta, "button[" .. (10.2 - (0.22) - 4) .. ",4.5;4,1", "exmatch_mode",
             { "Exact match - off",
                 "Exact match - on",
-                "Threshold"}) ..
+               "Threshold" }) ..
         pipeworks.fs_helpers.get_inv(6) ..
         "listring[]"
 
@@ -253,18 +253,21 @@ minetest.register_node("pipeworks:automatic_filter_injector", {
                     end
                     local item
                     local count = math.min(stack:get_count(), doRemove)
-                    if exmatch_mode == 1 then
-                        if  filterfor.count > count then
-                            return false -- not enough, fail
-                        else
-                            -- limit quantity to filter amount
-                            count = math.min(filterfor.count, count)
+                    if filterfor.count ~= nil then
+                        if exmatch_mode == 1 then
+                            if filterfor.count > count then
+                                return false -- not enough, fail
+                            else
+                                count = math.min(filterfor.count, count)
+                            end
                         end
-                    end
-                    if exmatch_mode == 2
-                    then
-                        count = count - filterfor.count
-
+                        if exmatch_mode == 2 then
+                            if count == 0 then
+                                return false
+                            else
+                                count = count - filterfor.count
+                            end
+                        end
                     end
                     if fromtube.remove_items then
                         -- it could be the entire stack...

--- a/mods/sbz_progression/quests/Pipeworks_and_fluid_transport.lua
+++ b/mods/sbz_progression/quests/Pipeworks_and_fluid_transport.lua
@@ -27,6 +27,16 @@ return {
     Now you can!
 
     The Automatic Filter-Injector takes stacks of items from nodes, and places them into tubes or other nodes.
+
+    The Automatic Filter-Injector has two settings:
+        The slot sequence allows you to change the order that items are taken out.
+            Priority: Takes items out in first in first out order
+            Randomilly: Takes items out in a random order
+            Rotation: Takes items out in a round robben facsion
+        The match mode sets the behavure when taking out items:
+            Exact match - off: If a item matches the filter it takes out the whole stack
+            Exact match - on: If a item matches the filter and the stack is higher the it takes out the filter count for example the filter is set to 5 matter and it is pulling from a stack of 60 matter it will pull out 5 matter until the stack is below 5 or empty
+            Threshold: If a item matches the filter and the stack is higher it takes out items until the stack matches the filter so I have a filter of 5 matter and a stack of 60 it will pull 55 matter out of the stack.
     ]],
         requires = { "Bear Arms", "Tubes" }
     },

--- a/mods/sbz_progression/quests/Pipeworks_and_fluid_transport.lua
+++ b/mods/sbz_progression/quests/Pipeworks_and_fluid_transport.lua
@@ -27,16 +27,16 @@ return {
     Now you can!
 
     The Automatic Filter-Injector takes stacks of items from nodes, and places them into tubes or other nodes.
-
-    The Automatic Filter-Injector has two settings:
-        The slot sequence allows you to change the order that items are taken out.
-            Priority: Takes items out in first in first out order
-            Randomilly: Takes items out in a random order
-            Rotation: Takes items out in a round robben facsion
-        The match mode sets the behavure when taking out items:
-            Exact match - off: If a item matches the filter it takes out the whole stack
-            Exact match - on: If a item matches the filter and the stack is higher the it takes out the filter count for example the filter is set to 5 matter and it is pulling from a stack of 60 matter it will pull out 5 matter until the stack is below 5 or empty
-            Threshold: If a item matches the filter and the stack is higher it takes out items until the stack matches the filter so I have a filter of 5 matter and a stack of 60 it will pull 55 matter out of the stack.
+        
+        The Automatic Filter-Injector has two settings:
+            The slot sequence allows you to change the order that items are taken out.
+                Priority: Takes items out in first out order
+                Randomly: Takes items out in a random order
+                Rotation: Takes items out in a round-robin order
+            The match mode sets the behavior when taking out items:
+                Exact match - off: If an item matches the filter, it takes out the whole stack
+                Exact match - on: If an item matches the filter and the stack are higher it takes out the filter count, for example the filter is set to 5 matter, and it is pulling from a stack of 60 matter it will pull out 5 matter until the stack is below 5 or empty
+                Threshold: If an item matches the filter and the stack are higher it takes out items until the stack matches the filter, so I have a filter of 5 matter and a stack of 60 it will pull 55 matter out of the stack.
     ]],
         requires = { "Bear Arms", "Tubes" }
     },


### PR DESCRIPTION
Adds a mode where the auto filter injector pulls out the item count up to the limit set by the amount in the item filter so say the threshold is set to 10 and their is 60 items in the chest it will only pull out 50 items leving 10 for other uses this would help with clog management by allow easier overflow management