### PR TITLE
fixes for deployer and node breaker

### DIFF
--- a/mods/sbz_bio/plants.lua
+++ b/mods/sbz_bio/plants.lua
@@ -258,7 +258,7 @@ sbz_api.register_plant("pyrograss", {
 minetest.register_craftitem("sbz_bio:pyrograss", {
     description = "Pyrograss",
     inventory_image = "pyrograss_4.png",
-    groups = { burn = 30, eat = 1 },
+    groups = { burn = 30, eat = 1, nb_nouse = 1 },
     on_place = sbz_api.plant_plant("sbz_bio:pyrograss_1", { "group:soil" })
 })
 
@@ -304,7 +304,7 @@ core.register_craft {
 minetest.register_craftitem("sbz_bio:razorgrass", {
     description = "Razorgrass",
     inventory_image = "razorgrass_4.png",
-    groups = { burn = 2, eat = -8 },
+    groups = { burn = 2, eat = -8, nb_nouse = 1 },
     eat_fx = { "Poisoned", "Slowed" },
     on_place = sbz_api.plant_plant("sbz_bio:razorgrass_1", { "group:soil" }),
     on_use = function(stack, user, pointed)
@@ -347,7 +347,7 @@ sbz_api.register_plant("cleargrass", {
 minetest.register_craftitem("sbz_bio:cleargrass", {
     description = "Cleargrass",
     inventory_image = "cleargrass_4.png",
-    groups = { burn = 0, eat = 0 },
+    groups = { burn = 0, eat = 0, nb_nouse = 1 },
     eat_fx = { "Cleared" },
     on_place = sbz_api.plant_plant("sbz_bio:cleargrass_1", { "group:soil" }),
     on_use = function(stack, user, pointed)
@@ -375,7 +375,7 @@ sbz_api.register_plant("stemfruit_plant", {
 minetest.register_craftitem("sbz_bio:stemfruit", {
     description = "Stemfruit",
     inventory_image = "stemfruit.png",
-    groups = { burn = 12, eat = 5 },
+    groups = { burn = 12, eat = 5, nb_nouse = 1 },
     on_place = function(itemstack, user, pointed)
         local use_pointed = "above"
         if pointed.switched then
@@ -440,7 +440,7 @@ minetest.register_craftitem("sbz_bio:warpshroom", {
         unlock_achievement(user:get_player_name(), "Not Chorus Fruit")
         return eat(itemstack, user, pointed)
     end,
-    groups = { ui_bio = 1, eat = 6 }
+    groups = { ui_bio = 1, eat = 6, nb_nouse = 1 }
 })
 --[[
 minetest.register_craft({
@@ -505,7 +505,7 @@ minetest.register_craftitem("sbz_bio:shockshroom", {
     description = "Shockshroom",
     inventory_image = "shockshroom_4.png",
     on_place = sbz_api.plant_plant("sbz_bio:shockshroom_1", { "group:soil" }),
-    groups = { ui_bio = 1, eat = -1 },
+    groups = { ui_bio = 1, eat = -1, nb_nouse = 1 },
     on_use = function(stack, user, pointed)
         if user.is_fake_player then return end
         playereffects.apply_effect_type("shocked", 180 / 0.5, user, 0.5)

--- a/mods/sbz_pipeworks/mod.conf
+++ b/mods/sbz_pipeworks/mod.conf
@@ -1,2 +1,2 @@
 name = pipeworks
-depends = fakelib, sbz_base, mesecons_mvps, unifieddyes
+depends = fakelib, creative, sbz_base, mesecons_mvps, unifieddyes

--- a/mods/sbz_pipeworks/wielder.lua
+++ b/mods/sbz_pipeworks/wielder.lua
@@ -227,7 +227,8 @@ pipeworks.register_wielder({
         local stack = fakeplayer:get_wielded_item()
         local old_stack = ItemStack(stack)
         local item_def = minetest.registered_items[stack:get_name()]
-        if item_def.on_use then
+        -- use only items that's allowed to be used
+        if item_def.on_use and core.get_item_group(stack:get_name(), 'nb_nouse') == 0 then
             stack = item_def.on_use(stack, fakeplayer, pointed) or stack
             fakeplayer:set_wielded_item(stack)
         else
@@ -293,6 +294,9 @@ pipeworks.register_wielder({
         local def = minetest.registered_items[stack:get_name()]
         if def and def.on_place then
             local new_stack, placed_pos = def.on_place(stack, fakeplayer, pointed)
+            if new_stack and core.is_creative_enabled(fakeplayer:get_player_name()) then
+                new_stack:take_item() -- undoes creative's auto-add
+            end
             fakeplayer:set_wielded_item(new_stack or stack)
             -- minetest.item_place_node doesn't play sound to the placer
             local sound = placed_pos and def.sounds and def.sounds.place


### PR DESCRIPTION
# bug 1: node breaker uses items not intended to be used by it
i solved it by adding `nb_nouse` group to plants (the only item with `on_place` + `on_use`) to prevent node breaker from using items not intended to be used by it. i hope no one is going to suggest a blanket no-op on all items with both of those set.

# bug 2: deployers of owners with `creative` priv does not take away nodes after placing it.
i added an edge case for this. deployer now reverses creative mod's on_placenode override, taking away item creative mod added. i'd prefer if creative mod is changed, but i don't know how people would feel about it.