### PR TITLE
Remove /s

### DIFF
--- a/mods/sbz_progression/quests/Pipeworks_and_fluid_transport.md
+++ b/mods/sbz_progression/quests/Pipeworks_and_fluid_transport.md
@@ -89,7 +89,7 @@ Requires: Automatic Filter-Injectors, Bear Arms, Emittrium Circuits
 
 ### Text
 
-Autocrafters automatically craft. You can make them craft as fast as possible, but they consume more power depending on the current crafts/s.
+Autocrafters automatically craft. You can make them craft as fast as possible, but they consume more power depending on the current crafts.
 
 ### Meta
 


### PR DESCRIPTION
Unless it is irony punctuation (which I believe it is not) this '/s' has nothing to do here. Maybe an asterisk was supposed to go there?