### PR TITLE
Fix an exploit with manual crafter

### DIFF
--- a/mods/sbz_power/manual_crafter.lua
+++ b/mods/sbz_power/manual_crafter.lua
@@ -154,13 +154,13 @@ core.register_node('sbz_power:manual_crafter', {
         meta:set_string(
             'formspec',
             [[
-				formspec_version[8]
-				size[10.25,9.6]
-				list[context;configure_craft;0.25,0.25;3,3]
-				list[context;configure_craft_output;5.25,1.525;1,1]
-				list[current_player;main;0.25,4.6;8,4]
-				button[8,0.25;2,1;configure;Configure]
-			]]
+                formspec_version[8]
+                size[10.25,9.6]
+                list[context;configure_craft;0.25,0.25;3,3]
+                list[context;configure_craft_output;5.25,1.525;1,1]
+                list[current_player;main;0.25,4.6;8,4]
+                button[8,0.25;2,1;configure;Configure]
+            ]]
         )
     end,
     groups = { matter = 2 },
@@ -169,8 +169,12 @@ core.register_node('sbz_power:manual_crafter', {
     end,
 
     allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
-        validate_craft(pos)
+        if from_list ~= to_list then return 0 end
         return count
+    end,
+
+    on_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
+        validate_craft(pos)
     end,
 
     allow_metadata_inventory_put = function(pos, listname, index, stack, player)
@@ -178,8 +182,11 @@ core.register_node('sbz_power:manual_crafter', {
             local from_inv = core.get_meta(pos):get_inventory()
             stack:set_count(1)
             from_inv:set_stack(listname, index, stack)
-            if listname == 'configure_craft_output' then configure_from_craft_output(pos, player) end
-            validate_craft(pos)
+            if listname == 'configure_craft_output' then
+                configure_from_craft_output(pos, player)
+            else
+                validate_craft(pos)
+            end
         end
         return 0
     end,
@@ -188,7 +195,13 @@ core.register_node('sbz_power:manual_crafter', {
         if listname == 'configure_craft' or listname == 'configure_craft_output' then
             local from_inv = core.get_meta(pos):get_inventory()
             from_inv:set_stack(listname, index, '')
-            validate_craft(pos)
+            if listname == 'configure_craft_output' then
+                from_inv:set_list('configure_craft', { '', '', '',
+                                                       '', '', '',
+                                                       '', '', '' })
+            else
+                validate_craft(pos)
+            end
         end
         return 0
     end,


### PR DESCRIPTION
While moving “virtual” items from the input grid to the output slot, it was possible to get a craft for cheap, or even completely for free. This PR fixes it, and also makes the manual crafter react more accurately to inventory changes.

<details>
<img width="542" height="508" alt="exploit_1" src="https://github.com/user-attachments/assets/ba6b58ea-5bd3-43fd-9a4f-457ee3cedacc" />
<img width="542" height="508" alt="exploit_2" src="https://github.com/user-attachments/assets/ad3fdfdf-2b81-4932-b6ed-61df393a6eca" />
<img width="542" height="508" alt="exploit_3" src="https://github.com/user-attachments/assets/af3964af-af75-4ad7-b612-728fe8c8ed04" />
<img width="542" height="508" alt="exploit_4" src="https://github.com/user-attachments/assets/390d781a-52c5-4f46-b737-0ca093ec8d62" />
<img width="609" height="678" alt="exploit_stonks" src="https://github.com/user-attachments/assets/e6c1cf2a-61b8-4844-bbaf-b6fe79067bef" />
</details>