### PR TITLE
Register new stats for crafting processor rebalance

### DIFF
--- a/mods/sbz_resources/processors_and_circuits.lua
+++ b/mods/sbz_resources/processors_and_circuits.lua
@@ -162,8 +162,8 @@ DESIGN:
 ]]
 sbz_api.crafting_processor_stats = {
     ['sbz_resources:simple_crafting_processor'] = { crafts = 1, power = 5 },
-    ['sbz_resources:quick_crafting_processor'] = { crafts = 8, power = 20 },
-    ['sbz_resources:fast_crafting_processor'] = { crafts = 32, power = 140 },
+    ['sbz_resources:fast_crafting_processor'] = { crafts = 8, power = 20 },
+    ['sbz_resources:very_fast_crafting_processor'] = { crafts = 32, power = 140 },
 
     ['sbz_resources:needlessly_expensive_crafting_processor'] = { crafts = 128, power = 640 },
     ['sbz_resources:omega_quantum_black_hole_whatever_crafting_processor'] = { crafts = 100000, power = 800 },


### PR DESCRIPTION
I was noticing while playing on the dev contrib version that the very fast processor wasn't registering as a crafting processor when placed in the autocrafter, and I think I tracked down why.  Turns out the fast processor had x32 speed as well.  I tried it out with these changes, and it appears to fix it ingame.  Really enjoying not needing neuts for these anymore.  :)