### PR TITLE
Fix tool speeds when used to dig blocks

### DIFF
--- a/mods/sbz_resources/tools.lua
+++ b/mods/sbz_resources/tools.lua
@@ -31,17 +31,16 @@ minetest.register_craftitem('sbz_resources:matter_annihilator', {
 })
 
 do -- Matter Annihilator Recipe
-    local _ = ''
-    local a = 'sbz_resources:antimatter_dust'
-    local M = 'sbz_resources:matter_blob'
-    local c = 'sbz_resources:charged_particle'
+    local AD = 'sbz_resources:antimatter_dust'
+    local MB = 'sbz_resources:matter_blob'
+    local CP = 'sbz_resources:charged_particle'
     
     minetest.register_craft {
         output = 'sbz_resources:matter_annihilator',
         recipe = {
-            { _, a, _ },
-            { M, c, M },
-            { _, M, _ },
+            { '', AD, '' },
+            { MB, CP, MB },
+            { '', MB, '' },
         },
     }
 end
@@ -77,17 +76,16 @@ minetest.register_craftitem('sbz_resources:antimatter_annihilator', {
 })
 
 do -- Antimatter Annihilator Recipe
-    local _ = ''
-    local m = 'sbz_resources:matter_dust'
-    local A = 'sbz_resources:antimatter_blob'
-    local c = 'sbz_resources:charged_particle'
+    local MD = 'sbz_resources:matter_dust'
+    local AB = 'sbz_resources:antimatter_blob'
+    local CP = 'sbz_resources:charged_particle'
     
     minetest.register_craft {
         output = 'sbz_resources:antimatter_annihilator',
         recipe = {
-            { _, m, _ },
-            { A, c, A },
-            { _, A, _ },
+            { '', MD, '' },
+            { AB, CP, AB },
+            { '', AB, '' },
         },
     }
 end
@@ -122,17 +120,17 @@ minetest.register_craftitem('sbz_resources:robotic_arm', {
 })
 
 do -- Robotic Arm Recipe
-    local M = 'sbz_resources:matter_annihilator'
-    local I = 'sbz_chem:iron_ingot'
-    local R = 'sbz_resources:reinforced_matter'
-    local E = 'sbz_resources:emittrium_circuit'
+    local MA = 'sbz_resources:matter_annihilator'
+    local II = 'sbz_chem:iron_ingot'
+    local RM = 'sbz_resources:reinforced_matter'
+    local EC = 'sbz_resources:emittrium_circuit'
     
     minetest.register_craft {
         output = 'sbz_resources:robotic_arm',
         recipe = {
-            { M, I, M },
-            { R, E, R },
-            { R, E, R },
+            { MA, II, MA },
+            { RM, EC, RM },
+            { RM, EC, RM },
         },
     }
 end
@@ -200,17 +198,17 @@ minetest.register_tool('sbz_resources:drill', {
 })
 
 do -- Drill Recipe
-    local T = 'sbz_chem:titanium_ingot'
-    local A = 'sbz_resources:robotic_arm'
-    local B = 'sbz_power:battery'
-    local R = 'sbz_resources:reinforced_matter'
-    local E = 'sbz_resources:emittrium_circuit'
+    local TI = 'sbz_chem:titanium_ingot'
+    local RA = 'sbz_resources:robotic_arm'
+    local Ba = 'sbz_power:battery'
+    local RM = 'sbz_resources:reinforced_matter'
+    local EC = 'sbz_resources:emittrium_circuit'
     
     minetest.register_craft {
         recipe = {
-            { T, A, T },
-            { T, B, T },
-            { R, E, R },
+            { TI, RA, TI },
+            { TI, Ba, TI },
+            { RM, EC, RM },
         },
         output = 'sbz_resources:drill',
     }


### PR DESCRIPTION
Main difference: The tools now have expressions to calculate their speeds when registered.  Uses named locals to avoid magic numbers for everything.  I intended to increase maintainability in case we want to mess around with the speeds later.  Essentially the mid-range strength block delay is inferred by the fastest and slowest one, linearly.  Now that I think about it, I probably could have just averaged it between them, but oh well.  I still find it weird that there are only three hardness levels.

Code readability change: I made the recipes a little more readable as well.  It's kind of hard picturing ingredients distributed to a grid if it's not compact. 

Fixes issue #220 