### PR TITLE
Recategorize antimatter blob decrafting recipe

### DIFF
--- a/mods/sbz_resources/nodes.lua
+++ b/mods/sbz_resources/nodes.lua
@@ -88,10 +88,11 @@ core.register_craft {
         { 'sbz_resources:antimatter_dust', 'sbz_resources:antimatter_dust', 'sbz_resources:antimatter_dust' },
     },
 }
-minetest.register_craft {
-    type = 'shapeless',
+
+sbz_api.recipe.register_craft {
+    type = 'crushing',
     output = 'sbz_resources:antimatter_dust 9',
-    recipe = {
+    items = {
         'sbz_resources:antimatter_blob',
     },
 }


### PR DESCRIPTION
There was a conflict with the antimatter plate recipe, and frog said making decrafting it a crushing recipe was fine.