### PR TITLE
Repair achievement unlock by [more thoroughly] fixing a misspelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,7 +234,7 @@
 
 # Release 9
 - New questline "Decorator"
-- Moved "Emitter Immitators" to the Decorator questline
+- Moved "Emitter Imitators" to the Decorator questline
 - New quest: "Photon Lamps" in Decorator Questline
 - Added Photon Lamps
 - Fixed a bug reported by @theidealist (ty)

--- a/mods/sbz_progression/quests/Decorator.md
+++ b/mods/sbz_progression/quests/Decorator.md
@@ -105,13 +105,13 @@ Normal matter isn't sturdy enough? Try this.
 
 Requires: A bigger platform, Matter Plates
 
-## Emitter Immitators
+## Emitter Imitators
 
 ### Text
 
-Emitter Immitators are decorational nodes providing light.  
+Emitter Imitators are decorational nodes providing light.  
   
-TIP: Emitter Immitators spawn a lot of particles when punched, try it!
+TIP: Emitter Imitators spawn a lot of particles when punched, try it!
 
 ### Meta
 
@@ -121,16 +121,16 @@ Requires: A bigger platform, More Antimatter
 
 ### Text
 
-Are Emitter Immitators too dim for you? Introducing: Photon Lamps!  
+Are Emitter Imitators too dim for you? Introducing: Photon Lamps!  
   
-With this revolutionary technology you can light up your world the same way as with Emitter Immitators just brighter!  
+With this revolutionary technology you can light up your world the same way as with Emitter Imitators just brighter!  
   
-To craft: A matter blob in the center, four matter plates in the corners and then just fill the rest of the spaces with regular Emitter Immitators.  
+To craft: A matter blob in the center, four matter plates in the corners and then just fill the rest of the spaces with regular Emitter Imitators.  
 Boom! You're done! Now you've got yourself a Photon Lamp! No more sitting in darkness! Yay!
 
 ### Meta
 
-Requires: Emitter Immitators, Matter Plates
+Requires: Emitter Imitators, Matter Plates
 
 ## Phosphor
 
@@ -140,7 +140,7 @@ On the other hand, you can craft an Emittrium Circuit with an Emitter Imitator t
 
 ### Meta
 
-Requires: Emitter Immitators, Emittrium Circuits
+Requires: Emitter Imitators, Emittrium Circuits
 
 ## Signs
 


### PR DESCRIPTION
This was made a problem originally when I fixed a typo in all but the markdown doc.  I hadn't realized it cued off the contents in there (but I probably should have), and I didn't think about it because I've had those as a search exclusion in my editor.  Thanks, iisu on Discord for the heads up about it!

Fix tested successfully on my end:
https://github.com/user-attachments/assets/bb561ad6-734e-4f91-a333-bc73236c2931

